### PR TITLE
Feature/sis 11114 removing return data only flag

### DIFF
--- a/api-services/foundations-api.service.js
+++ b/api-services/foundations-api.service.js
@@ -26,11 +26,7 @@ export class FoundationsApiService extends ApiService {
             return response
         }
 
-        this.processProtectiveMonitoring(foundationApiRequestOptions, response)
-
-        if (foundationApiRequestOptions.returnDataOnly) {
-            return response.data
-        }
+        this.processProtectiveMonitoring(foundationApiRequestOptions.protectiveMonitoring, response)
 
         return response
     }
@@ -38,26 +34,25 @@ export class FoundationsApiService extends ApiService {
     // Exception response processing
 
     processException (exception, foundationApiRequestConfig, foundationApiRequestOptions) {
-        this.logStandardException(foundationApiRequestConfig, exception)
+        this.logException(foundationApiRequestConfig, exception)
 
         // The original api service created in Licensing, simply consumed the error after logging, however returning the response will be more useful
         if (!foundationApiRequestOptions) {
             return exception.response
         }
 
-        this.processProtectiveMonitoring(foundationApiRequestOptions, null, exception)
+        this.processProtectiveMonitoring(foundationApiRequestOptions.protectiveMonitoring, null, exception)
 
         return exception.response
     }
 
-    logStandardException (foundationApiRequestConfig, exception) {
+    logException (foundationApiRequestConfig, exception) {
         this.logApiServiceException(foundationApiRequestConfig.method, foundationApiRequestConfig.url, exception)
     }
 
     // Protective monitoring
 
-    processProtectiveMonitoring (foundationApiRequestOptions, response, exception) {
-        const protectiveMonitoring = foundationApiRequestOptions.protectiveMonitoring
+    processProtectiveMonitoring (protectiveMonitoring, response, exception) {
         if (!protectiveMonitoring) {
             return
         }

--- a/api-services/helpers.js
+++ b/api-services/helpers.js
@@ -82,23 +82,14 @@ function buildFoundationsApiProtectiveMonitoring (environment, successfulMonitor
     }
 }
 
-function buildFoundationsApiResponseOptions (returnDataOnly, protectiveMonitoring) {
-    if (!returnDataOnly && !protectiveMonitoring) {
+function buildFoundationsApiResponseOptions (protectiveMonitoring) {
+    if (!protectiveMonitoring) {
         throw new Error('buildFoundationsApiResponseOptions requires params')
     }
 
-    const responseOptions = { }
-
-    if (returnDataOnly) {
-        if (returnDataOnly !== true && returnDataOnly !== false) {
-            throw new Error(`returnDataOnly is expected to be a boolean, but received '${returnDataOnly}'`)
-        }
-        responseOptions.returnDataOnly = returnDataOnly
-    }
     // Could validate protectiveMonitoring
-    if (protectiveMonitoring) {
-        responseOptions.protectiveMonitoring = protectiveMonitoring
-    }
+    const responseOptions = { protectiveMonitoring }
+
     return responseOptions
 }
 

--- a/api-services/helpers.js
+++ b/api-services/helpers.js
@@ -105,14 +105,27 @@ function validateApiRequestConfig (requestConfiguration) {
     }
 }
 
-function throwUnexpectedResponseCodeError (response) {
+function validateResponse (response) {
     if (!response) {
-        throw new Error('A response is required to throw unexpected response code error')
+        throw new Error('A response is required')
     }
 
     if (!response.status) {
         throw new Error('Response doesnt contain a status')
     }
+}
+
+function returnDataIfSuccessfulOrThrowError (response, successStatusCode = 200) {
+    validateResponse(response)
+
+    if (response.status === successStatusCode) {
+        return response.data
+    }
+    throwUnexpectedResponseCodeError(response)
+}
+
+function throwUnexpectedResponseCodeError (response) {
+    validateResponse(response)
 
     throw new Error(`Unexpected response code '${response.status}', see log for full details`)
 }
@@ -131,5 +144,6 @@ export {
 
     validateApiRequestConfig,
 
+    returnDataIfSuccessfulOrThrowError,
     throwUnexpectedResponseCodeError
 }

--- a/api-services/helpers.js
+++ b/api-services/helpers.js
@@ -105,6 +105,18 @@ function validateApiRequestConfig (requestConfiguration) {
     }
 }
 
+function throwUnexpectedResponseCodeError (response) {
+    if (!response) {
+        throw new Error('A response is required to throw unexpected response code error')
+    }
+
+    if (!response.status) {
+        throw new Error('Response doesnt contain a status')
+    }
+
+    throw new Error(`Unexpected response code '${response.status}', see log for full details`)
+}
+
 export {
     checkForRequestConfiguration,
 
@@ -117,5 +129,7 @@ export {
     buildFoundationsApiProtectiveMonitoring,
     buildFoundationsApiResponseOptions,
 
-    validateApiRequestConfig
+    validateApiRequestConfig,
+
+    throwUnexpectedResponseCodeError
 }

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ import { ProtectiveMonitoringService } from './services/protective-monitoring.se
 import {
     addMaxContentLengthToRequestConfiguration, addMaxBodyLengthToRequestConfiguration, buildFoundationsApiRequestConfig,
     buildFoundationsApiProtectiveMonitoring,
-    buildFoundationsApiResponseOptions } from './api-services/helpers'
+    buildFoundationsApiResponseOptions,
+    throwUnexpectedResponseCodeError } from './api-services/helpers'
 import { buildProtectiveMonitoringOptions } from './services/helpers'
 
 export {
@@ -21,6 +22,7 @@ export {
     buildFoundationsApiRequestConfig,
     buildFoundationsApiProtectiveMonitoring,
     buildFoundationsApiResponseOptions,
+    throwUnexpectedResponseCodeError,
 
     ProtectiveMonitoringService,
     buildProtectiveMonitoringOptions

--- a/index.js
+++ b/index.js
@@ -2,7 +2,10 @@ import { AuditCodeEnum, PmcCodeEnum, PriorityEnum } from './enums/protective-mon
 import { ApiService } from './api-services/api.service'
 import { FoundationsApiService } from './api-services/foundations-api.service'
 import { ProtectiveMonitoringService } from './services/protective-monitoring.service'
-import { buildFoundationsApiRequestConfig, buildFoundationsApiProtectiveMonitoring, buildFoundationsApiResponseOptions } from './api-services/helpers'
+import {
+    addMaxContentLengthToRequestConfiguration, addMaxBodyLengthToRequestConfiguration, buildFoundationsApiRequestConfig,
+    buildFoundationsApiProtectiveMonitoring,
+    buildFoundationsApiResponseOptions } from './api-services/helpers'
 import { buildProtectiveMonitoringOptions } from './services/helpers'
 
 export {
@@ -13,6 +16,8 @@ export {
     ApiService,
     FoundationsApiService,
 
+    addMaxContentLengthToRequestConfiguration,
+    addMaxBodyLengthToRequestConfiguration,
     buildFoundationsApiRequestConfig,
     buildFoundationsApiProtectiveMonitoring,
     buildFoundationsApiResponseOptions,

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ import {
     addMaxContentLengthToRequestConfiguration, addMaxBodyLengthToRequestConfiguration, buildFoundationsApiRequestConfig,
     buildFoundationsApiProtectiveMonitoring,
     buildFoundationsApiResponseOptions,
-    throwUnexpectedResponseCodeError } from './api-services/helpers'
+    returnDataIfSuccessfulOrThrowError, throwUnexpectedResponseCodeError } from './api-services/helpers'
 import { buildProtectiveMonitoringOptions } from './services/helpers'
 
 export {
@@ -22,6 +22,7 @@ export {
     buildFoundationsApiRequestConfig,
     buildFoundationsApiProtectiveMonitoring,
     buildFoundationsApiResponseOptions,
+    returnDataIfSuccessfulOrThrowError,
     throwUnexpectedResponseCodeError,
 
     ProtectiveMonitoringService,

--- a/test/api-services/helper-specs.js
+++ b/test/api-services/helper-specs.js
@@ -195,12 +195,8 @@ describe('Api.Service Helpers', function () {
 
     describe('#buildFoundationsApiResponseOptions', function () {
         it('should return correct result', async function () {
-            const returnDataOnly = true
             const protectiveMonitoring = { 'pm': 'protectiveMonitoringOptions' }
-            const foundationsApiResponseOptions = buildFoundationsApiResponseOptions(returnDataOnly, protectiveMonitoring)
-
-            expect(foundationsApiResponseOptions).to.have.property('returnDataOnly')
-            expect(foundationsApiResponseOptions.returnDataOnly).to.equal(returnDataOnly)
+            const foundationsApiResponseOptions = buildFoundationsApiResponseOptions(protectiveMonitoring)
 
             expect(foundationsApiResponseOptions).to.have.property('protectiveMonitoring')
             expect(foundationsApiResponseOptions.protectiveMonitoring).to.equal(protectiveMonitoring)
@@ -208,10 +204,6 @@ describe('Api.Service Helpers', function () {
 
         it('should return correct empty result', async function () {
             await expectThrowsAsync(() => buildFoundationsApiResponseOptions(), 'buildFoundationsApiResponseOptions requires params')
-        })
-
-        it('should throw error when non boolean value passed for returnDataOnly', async function () {
-            await expectThrowsAsync(() => buildFoundationsApiResponseOptions('nonBoolean'), 'returnDataOnly is expected to be a boolean, but received \'nonBoolean\'')
         })
     })
 })

--- a/test/api-services/helper-specs.js
+++ b/test/api-services/helper-specs.js
@@ -2,19 +2,20 @@
 /* eslint-disable no-new */
 import { describe, it } from 'mocha'
 import chai from 'chai'
-import { expectThrowsAsync } from '../helpers'
+import { expectThrows } from '../helpers'
 import {
     addMaxContentLengthToRequestConfiguration, addMaxBodyLengthToRequestConfiguration,
     buildApiRequestConfig, buildFoundationsApiRequestConfig,
     buildFoundationsApiProtectiveMonitoring, buildFoundationsApiResponseOptions,
-    validateApiRequestConfig, throwUnexpectedResponseCodeError } from '../../api-services/helpers'
+    validateApiRequestConfig,
+    throwUnexpectedResponseCodeError, returnDataIfSuccessfulOrThrowError } from '../../api-services/helpers'
 
 const expect = chai.expect
 
 describe('Api.Service Helpers', function () {
     describe('#checkForRequestConfiguration', function () {
         it('should throw error when no request config provided', async function () {
-            await expectThrowsAsync(() => addMaxContentLengthToRequestConfiguration(), 'Request Config required')
+            await expectThrows(() => addMaxContentLengthToRequestConfiguration(), 'Request Config required')
         })
     })
 
@@ -29,11 +30,11 @@ describe('Api.Service Helpers', function () {
         })
 
         it('should throw error when no request config provided', async function () {
-            await expectThrowsAsync(() => addMaxContentLengthToRequestConfiguration(), 'Request Config required')
+            await expectThrows(() => addMaxContentLengthToRequestConfiguration(), 'Request Config required')
         })
 
         it('should throw error when no maxContentLength provided', async function () {
-            await expectThrowsAsync(() => addMaxContentLengthToRequestConfiguration({}), 'maxContentLength required')
+            await expectThrows(() => addMaxContentLengthToRequestConfiguration({}), 'maxContentLength required')
         })
     })
 
@@ -48,17 +49,17 @@ describe('Api.Service Helpers', function () {
         })
 
         it('should throw error when no request config provided', async function () {
-            await expectThrowsAsync(() => addMaxBodyLengthToRequestConfiguration(), 'Request Config required')
+            await expectThrows(() => addMaxBodyLengthToRequestConfiguration(), 'Request Config required')
         })
 
         it('should throw error when no maxBodyLength provided', async function () {
-            await expectThrowsAsync(() => addMaxBodyLengthToRequestConfiguration({}), 'maxBodyLength required')
+            await expectThrows(() => addMaxBodyLengthToRequestConfiguration({}), 'maxBodyLength required')
         })
     })
 
     describe('#buildApiRequestConfig', function () {
         it('should throw error when no url provided', async function () {
-            await expectThrowsAsync(() => buildApiRequestConfig(), 'Url is required')
+            await expectThrows(() => buildApiRequestConfig(), 'Url is required')
         })
 
         it('should add url to request config', async function () {
@@ -90,7 +91,7 @@ describe('Api.Service Helpers', function () {
 
     describe('#buildFoundationsApiRequestConfig', function () {
         it('should throw error when no url provided', async function () {
-            await expectThrowsAsync(() => buildFoundationsApiRequestConfig(), 'Url is required')
+            await expectThrows(() => buildFoundationsApiRequestConfig(), 'Url is required')
         })
 
         it('should add url to request config', async function () {
@@ -162,11 +163,11 @@ describe('Api.Service Helpers', function () {
         })
 
         it('should throw error when no environment provided', async function () {
-            await expectThrowsAsync(() => buildFoundationsApiProtectiveMonitoring(), 'Environment is required')
+            await expectThrows(() => buildFoundationsApiProtectiveMonitoring(), 'Environment is required')
         })
 
         it('should throw error when no monitoring options provided', async function () {
-            await expectThrowsAsync(() => buildFoundationsApiProtectiveMonitoring('testEnvironment'), 'Either success or exception monintoring options are required')
+            await expectThrows(() => buildFoundationsApiProtectiveMonitoring('testEnvironment'), 'Either success or exception monintoring options are required')
         })
     })
 
@@ -180,23 +181,23 @@ describe('Api.Service Helpers', function () {
         })
 
         it('should return correct empty result', async function () {
-            await expectThrowsAsync(() => buildFoundationsApiResponseOptions(), 'buildFoundationsApiResponseOptions requires params')
+            await expectThrows(() => buildFoundationsApiResponseOptions(), 'buildFoundationsApiResponseOptions requires params')
         })
     })
 
     describe('#validateApiRequestConfig', function () {
         it('should throw error when no request config provided', async function () {
-            await expectThrowsAsync(() => validateApiRequestConfig(), 'Request Config required')
+            await expectThrows(() => validateApiRequestConfig(), 'Request Config required')
         })
 
         it('should throw error when no method provided', async function () {
             const requestConfig = {}
-            await expectThrowsAsync(() => validateApiRequestConfig(requestConfig), 'Request Config requires a http method')
+            await expectThrows(() => validateApiRequestConfig(requestConfig), 'Request Config requires a http method')
         })
 
         it('should throw error when no headers property is provided', async function () {
             const requestConfig = { 'method': 'get' }
-            await expectThrowsAsync(() => validateApiRequestConfig(requestConfig), 'Request Config requires a content-type header')
+            await expectThrows(() => validateApiRequestConfig(requestConfig), 'Request Config requires a content-type header')
         })
 
         it('should throw error when no content-type header property is provided', async function () {
@@ -204,21 +205,47 @@ describe('Api.Service Helpers', function () {
                 'method': 'get',
                 'headers': {}
             }
-            await expectThrowsAsync(() => validateApiRequestConfig(requestConfig), 'Request Config requires a content-type header')
+            await expectThrows(() => validateApiRequestConfig(requestConfig), 'Request Config requires a content-type header')
+        })
+    })
+
+    describe('#returnDataIfSuccessfulOrThrowError', function () {
+        it('should throw error stating response is required', async function () {
+            await expectThrows(() => returnDataIfSuccessfulOrThrowError(), 'A response is required')
+        })
+
+        it('should throw error stating response.status is required', async function () {
+            await expectThrows(() => returnDataIfSuccessfulOrThrowError({}), 'Response doesnt contain a status')
+        })
+
+        it('should return correct data with default code', async function () {
+            const result = returnDataIfSuccessfulOrThrowError({ status: 200, data: { 'test': '200' } })
+            expect(result).to.have.property('test')
+            expect(result.test).to.equal('200')
+        })
+
+        it('should return correct data with specific code', async function () {
+            const result = returnDataIfSuccessfulOrThrowError({ status: 201, data: { 'test': '201' } }, 201)
+            expect(result).to.have.property('test')
+            expect(result.test).to.equal('201')
+        })
+
+        it('should throw correct error', async function () {
+            await expectThrows(() => returnDataIfSuccessfulOrThrowError({ status: 403 }), 'Unexpected response code \'403\', see log for full details')
         })
     })
 
     describe('#throwUnexpectedResponseCodeError', function () {
         it('should throw error stating response is required', async function () {
-            await expectThrowsAsync(() => throwUnexpectedResponseCodeError(), 'A response is required to throw unexpected response code error')
+            await expectThrows(() => throwUnexpectedResponseCodeError(), 'A response is required')
         })
 
         it('should throw error stating response.status is required', async function () {
-            await expectThrowsAsync(() => throwUnexpectedResponseCodeError({}), 'Response doesnt contain a status')
+            await expectThrows(() => throwUnexpectedResponseCodeError({}), 'Response doesnt contain a status')
         })
 
         it('should throw correct error', async function () {
-            await expectThrowsAsync(() => throwUnexpectedResponseCodeError({ status: 403 }), 'Unexpected response code \'403\', see log for full details')
+            await expectThrows(() => throwUnexpectedResponseCodeError({ status: 403 }), 'Unexpected response code \'403\', see log for full details')
         })
     })
 })

--- a/test/api-services/helper-specs.js
+++ b/test/api-services/helper-specs.js
@@ -4,9 +4,10 @@ import { describe, it } from 'mocha'
 import chai from 'chai'
 import { expectThrowsAsync } from '../helpers'
 import {
-    addMaxContentLengthToRequestConfiguration, addMaxBodyLengthToRequestConfiguration, validateApiRequestConfig,
+    addMaxContentLengthToRequestConfiguration, addMaxBodyLengthToRequestConfiguration,
     buildApiRequestConfig, buildFoundationsApiRequestConfig,
-    buildFoundationsApiProtectiveMonitoring, buildFoundationsApiResponseOptions } from '../../api-services/helpers'
+    buildFoundationsApiProtectiveMonitoring, buildFoundationsApiResponseOptions,
+    validateApiRequestConfig, throwUnexpectedResponseCodeError } from '../../api-services/helpers'
 
 const expect = chai.expect
 
@@ -52,30 +53,6 @@ describe('Api.Service Helpers', function () {
 
         it('should throw error when no maxBodyLength provided', async function () {
             await expectThrowsAsync(() => addMaxBodyLengthToRequestConfiguration({}), 'maxBodyLength required')
-        })
-    })
-
-    describe('#validateApiRequestConfig', function () {
-        it('should throw error when no request config provided', async function () {
-            await expectThrowsAsync(() => validateApiRequestConfig(), 'Request Config required')
-        })
-
-        it('should throw error when no method provided', async function () {
-            const requestConfig = {}
-            await expectThrowsAsync(() => validateApiRequestConfig(requestConfig), 'Request Config requires a http method')
-        })
-
-        it('should throw error when no headers property is provided', async function () {
-            const requestConfig = { 'method': 'get' }
-            await expectThrowsAsync(() => validateApiRequestConfig(requestConfig), 'Request Config requires a content-type header')
-        })
-
-        it('should throw error when no content-type header property is provided', async function () {
-            const requestConfig = {
-                'method': 'get',
-                'headers': {}
-            }
-            await expectThrowsAsync(() => validateApiRequestConfig(requestConfig), 'Request Config requires a content-type header')
         })
     })
 
@@ -204,6 +181,44 @@ describe('Api.Service Helpers', function () {
 
         it('should return correct empty result', async function () {
             await expectThrowsAsync(() => buildFoundationsApiResponseOptions(), 'buildFoundationsApiResponseOptions requires params')
+        })
+    })
+
+    describe('#validateApiRequestConfig', function () {
+        it('should throw error when no request config provided', async function () {
+            await expectThrowsAsync(() => validateApiRequestConfig(), 'Request Config required')
+        })
+
+        it('should throw error when no method provided', async function () {
+            const requestConfig = {}
+            await expectThrowsAsync(() => validateApiRequestConfig(requestConfig), 'Request Config requires a http method')
+        })
+
+        it('should throw error when no headers property is provided', async function () {
+            const requestConfig = { 'method': 'get' }
+            await expectThrowsAsync(() => validateApiRequestConfig(requestConfig), 'Request Config requires a content-type header')
+        })
+
+        it('should throw error when no content-type header property is provided', async function () {
+            const requestConfig = {
+                'method': 'get',
+                'headers': {}
+            }
+            await expectThrowsAsync(() => validateApiRequestConfig(requestConfig), 'Request Config requires a content-type header')
+        })
+    })
+
+    describe('#throwUnexpectedResponseCodeError', function () {
+        it('should throw error stating response is required', async function () {
+            await expectThrowsAsync(() => throwUnexpectedResponseCodeError(), 'A response is required to throw unexpected response code error')
+        })
+
+        it('should throw error stating response.status is required', async function () {
+            await expectThrowsAsync(() => throwUnexpectedResponseCodeError({}), 'Response doesnt contain a status')
+        })
+
+        it('should throw correct error', async function () {
+            await expectThrowsAsync(() => throwUnexpectedResponseCodeError({ status: 403 }), 'Unexpected response code \'403\', see log for full details')
         })
     })
 })

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -24,6 +24,19 @@ function checkRequestData (response, expectedPropertyName, expectedPropertyValue
     expect(parsedData[expectedPropertyName]).to.equal(expectedPropertyValue)
 }
 
+async function expectThrows (method, errorMessage) {
+    let error = null
+    try {
+        method()
+    } catch (err) {
+        error = err
+    }
+    expect(error).to.be.an('Error')
+    if (errorMessage) {
+        expect(error.message).to.equal(errorMessage)
+    }
+}
+
 async function expectThrowsAsync (method, errorMessage) {
     let error = null
     try {
@@ -77,6 +90,7 @@ export {
     checkResponseForRequestData,
     checkRequestData,
 
+    expectThrows,
     expectThrowsAsync,
 
     checkResponseStatusCode,


### PR DESCRIPTION
Removing the return data only flag as after beginning to implement this in various applications call it became apparent that its clearer if the using call deals with the response in its entirety 