### PR TITLE
add the component to buildFoundationsApiRequestConfig

### DIFF
--- a/api-services/helpers.js
+++ b/api-services/helpers.js
@@ -47,6 +47,11 @@ function buildApiRequestConfig (url, headers, data) {
 }
 
 function buildFoundationsApiRequestConfig (url, headers, data, originatingRequestId) {
+
+    if (!process.env.COMPONENT) {
+        throw new Error('Component is expected in the user environment')
+    }
+
     const requestConfiguration = buildApiRequestConfig(url, headers, data)
 
     let requestConfigurationHeaders = requestConfiguration.headers
@@ -62,9 +67,7 @@ function buildFoundationsApiRequestConfig (url, headers, data, originatingReques
         requestConfigurationHeaders[httpHeadersEnum.CORRELATION_ID] = originatingRequestId
     }
 
-    if (process.env.COMPONENT) {
-        requestConfigurationHeaders['vmd-component'] = process.env.COMPONENT
-    }
+    requestConfigurationHeaders['vmd-component'] = process.env.COMPONENT
 
     requestConfiguration.headers = requestConfigurationHeaders
 

--- a/api-services/helpers.js
+++ b/api-services/helpers.js
@@ -50,6 +50,7 @@ function buildFoundationsApiRequestConfig (url, headers, data, originatingReques
     const requestConfiguration = buildApiRequestConfig(url, headers, data)
 
     let requestConfigurationHeaders = requestConfiguration.headers
+
     if (!requestConfigurationHeaders || !requestConfigurationHeaders['Content-Type']) {
         // No content type, default to json
         requestConfigurationHeaders = requestConfigurationHeaders || {}
@@ -59,6 +60,10 @@ function buildFoundationsApiRequestConfig (url, headers, data, originatingReques
     if (originatingRequestId) {
         // At this point we should always have a headers object
         requestConfigurationHeaders[httpHeadersEnum.CORRELATION_ID] = originatingRequestId
+    }
+
+    if (process.env.COMPONENT) {
+        requestConfigurationHeaders['vmd-component'] = process.env.COMPONENT
     }
 
     requestConfiguration.headers = requestConfigurationHeaders

--- a/test/api-services/foundations-api.service-specs.js
+++ b/test/api-services/foundations-api.service-specs.js
@@ -18,6 +18,10 @@ import nock from 'nock'
 const expect = chai.expect
 
 describe('FoundationsApi.Service', function () {
+    beforeEach(function () {
+        process.env.COMPONENT = 'TESTCOMPONENT'
+    })
+
     describe('#get (passed through to )', function () {
         const getDomain = 'http://test-get.foundationsapiservice.com'
         const getUri = '/api/1'

--- a/test/api-services/helper-specs.js
+++ b/test/api-services/helper-specs.js
@@ -142,6 +142,17 @@ describe('Api.Service Helpers', function () {
 
             expect(requestConfig).to.have.property('data')
             expect(requestConfig.data).to.equal(data)
+
+            expect(requestConfig.headers).not.to.have.property('vmd-component')
+        })
+
+        it('should add the component header from the process env', async function () {
+            process.env.COMPONENT = 'TESTCOMPONENT'
+            const url = 'test.url'
+            const data = { 'testData': 'Some Test Data' }
+            const requestConfig = buildFoundationsApiRequestConfig(url, null, data)
+
+            expect(requestConfig.headers['vmd-component']).to.equal('TESTCOMPONENT')
         })
     })
 

--- a/test/api-services/helper-specs.js
+++ b/test/api-services/helper-specs.js
@@ -90,6 +90,10 @@ describe('Api.Service Helpers', function () {
     })
 
     describe('#buildFoundationsApiRequestConfig', function () {
+        beforeEach(function () {
+            process.env.COMPONENT = 'TESTCOMPONENT'
+        })
+
         it('should throw error when no url provided', async function () {
             await expectThrows(() => buildFoundationsApiRequestConfig(), 'Url is required')
         })
@@ -100,6 +104,7 @@ describe('Api.Service Helpers', function () {
 
             expect(requestConfig).to.have.property('url')
             expect(requestConfig.url).to.equal(url)
+            expect(requestConfig.headers['vmd-component']).to.equal('TESTCOMPONENT')
         })
 
         it('should add default content-type header to request config when not provided', async function () {
@@ -109,6 +114,7 @@ describe('Api.Service Helpers', function () {
             expect(requestConfig).to.have.property('headers')
             expect(requestConfig.headers).to.have.property('Content-Type')
             expect(requestConfig.headers['Content-Type']).to.equal('application/json')
+            expect(requestConfig.headers['vmd-component']).to.equal('TESTCOMPONENT')
         })
 
         it('should add content-type header to request config when provided', async function () {
@@ -120,6 +126,7 @@ describe('Api.Service Helpers', function () {
             expect(requestConfig).to.have.property('headers')
             expect(requestConfig.headers).to.have.property('Content-Type')
             expect(requestConfig.headers['Content-Type']).to.equal(customContentType)
+            expect(requestConfig.headers['vmd-component']).to.equal('TESTCOMPONENT')
         })
 
         it('should add additional headers to request config when provided', async function () {
@@ -133,6 +140,7 @@ describe('Api.Service Helpers', function () {
             expect(requestConfig.headers['Content-Type']).to.equal('application/json')
             expect(requestConfig.headers).to.have.property('testHeader')
             expect(requestConfig.headers['testHeader']).to.equal('Some Test header')
+            expect(requestConfig.headers['vmd-component']).to.equal('TESTCOMPONENT')
         })
 
         it('should add data to request config when provided', async function () {
@@ -142,16 +150,6 @@ describe('Api.Service Helpers', function () {
 
             expect(requestConfig).to.have.property('data')
             expect(requestConfig.data).to.equal(data)
-
-            expect(requestConfig.headers).not.to.have.property('vmd-component')
-        })
-
-        it('should add the component header from the process env', async function () {
-            process.env.COMPONENT = 'TESTCOMPONENT'
-            const url = 'test.url'
-            const data = { 'testData': 'Some Test Data' }
-            const requestConfig = buildFoundationsApiRequestConfig(url, null, data)
-
             expect(requestConfig.headers['vmd-component']).to.equal('TESTCOMPONENT')
         })
     })


### PR DESCRIPTION
## Ticket
https://vmddefra.atlassian.net/browse/APT-810

## Overview: 
To help make protective monitoring better we want to include the component (ie. ServiceHub, Licencing, SecureMessaging, CRM) with the event that is logged. 

This approach will allow each application to use process.env to specify its own component.
setting axios.defaults.headers.common['vmd-component'] = 'CRM' in the CRM application was not working