### PR TITLE
Write to console log on unexpected response error

### DIFF
--- a/api-services/helpers.js
+++ b/api-services/helpers.js
@@ -135,6 +135,7 @@ function returnDataIfSuccessfulOrThrowError (response, successStatusCode = 200) 
 function throwUnexpectedResponseCodeError (response) {
     validateResponse(response)
 
+    console.log(`Unexpected response code ${response.status}, expected ${successStatusCode}), URL: ${response.config.url}`)
     throw new Error(`Unexpected response code '${response.status}', see log for full details`)
 }
 

--- a/api-services/helpers.js
+++ b/api-services/helpers.js
@@ -135,7 +135,7 @@ function returnDataIfSuccessfulOrThrowError (response, successStatusCode = 200) 
 function throwUnexpectedResponseCodeError (response) {
     validateResponse(response)
 
-    console.log(`Unexpected response code ${response.status}, expected ${successStatusCode}), URL: ${response.config.url}`)
+    console.error(`Unexpected response code ${response.status}, expected ${successStatusCode}), URL: ${response.config.url}`)
     throw new Error(`Unexpected response code '${response.status}', see log for full details`)
 }
 


### PR DESCRIPTION
Related ticket: https://vmddefra.atlassian.net/browse/DEV-12282

Test to see if an unexpected response can be logged to the console even if APM captures the error.
Works when tested locally with APM enabled.

_Note: possibly needs further investigation to determine why the exception is not being  logged to file._